### PR TITLE
Better support for custom packaging types (#12)

### DIFF
--- a/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
+++ b/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
@@ -10,9 +10,11 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.FilenameUtils;
@@ -30,6 +32,7 @@ import org.codehaus.plexus.util.interpolation.ObjectBasedValueSource;
 import org.codehaus.plexus.util.interpolation.RegexBasedInterpolator;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.sonatype.plexus.build.incremental.BuildContext;
+import org.zeroturnaround.javarebel.maven.model.PackagingTypeMapping;
 import org.zeroturnaround.javarebel.maven.model.RebelClasspath;
 import org.zeroturnaround.javarebel.maven.model.RebelClasspathResource;
 import org.zeroturnaround.javarebel.maven.model.RebelResource;
@@ -72,6 +75,13 @@ public class GenerateRebelMojo extends AbstractMojo {
    * @required
    */
   private String packaging;
+
+  /**
+   * Packaging type mappings to apply.
+   * 
+   * @parameter
+   */
+  private List<PackagingTypeMapping> packagingTypeMappings;
 
   /**
    * The directory containing generated classes.
@@ -283,13 +293,22 @@ public class GenerateRebelMojo extends AbstractMojo {
 
     getLog().info("Processing " + getProject().getGroupId() + ":" + getProject().getArtifactId() + " with packaging " + packaging);
 
+    Map<String, String> processedPackagingTypeMappings = processPackagingTypeMappings();
+    String mappedPackaging = processedPackagingTypeMappings.get(packaging);
+    if (mappedPackaging == null) {
+      mappedPackaging = packaging;
+    } else {
+      getLog().debug("Mapped packaging type " + packaging + " to type " + mappedPackaging);
+    }
+
     RebelXmlBuilder builder = null;
-    if (WAR_PACKAGING.contains(packaging)) {
+    if (WAR_PACKAGING.contains(mappedPackaging)) {
       builder = buildWar();
-    } else if (JAR_PACKAGING.contains(packaging)) {
+    } else if (JAR_PACKAGING.contains(mappedPackaging)) {
       builder = buildJar();
     } else {
-      getLog().warn("Unsupported packaging type: " + packaging);
+      // the mapping logic guarantees that (packaging == mappedPackaging) if this statement is reached
+      getLog().warn("Unsupported packaging type: " + mappedPackaging);
     }
 
     if (builder != null) {
@@ -320,6 +339,34 @@ public class GenerateRebelMojo extends AbstractMojo {
         }
       }
     }
+  }
+
+  /**
+   * Process the packaging type mapping configuration. The values in the
+   * returned map are guaranteed to be supported by the plugin.
+   */
+  private Map<String, String> processPackagingTypeMappings() {
+    Set<String> allStandardPackagingTypes = new HashSet<String>();
+    allStandardPackagingTypes.addAll(JAR_PACKAGING);
+    allStandardPackagingTypes.addAll(WAR_PACKAGING);
+
+    Map<String, String> processedPackagingTypeMappings = new HashMap<String, String>();
+    for (PackagingTypeMapping packagingTypeMapping : packagingTypeMappings) {
+      String type = packagingTypeMapping.getType();
+      String mapping = packagingTypeMapping.getMapping();
+
+      if (allStandardPackagingTypes.contains(mapping)) {
+        String existingMapping = processedPackagingTypeMappings.get(type);
+        if (existingMapping == null) {
+          processedPackagingTypeMappings.put(type, mapping);
+        } else {
+          getLog().warn("Packaging type " + type + " is already mapped to type " + existingMapping + "; ignoring conflicting mapping: " + type + " -> " + mapping);
+        }
+      } else {
+        getLog().warn("Ignoring packaging type mapping with unsupported target type: " + type + " -> " + mapping);
+      }
+    }
+    return processedPackagingTypeMappings;
   }
 
   /**

--- a/src/main/java/org/zeroturnaround/javarebel/maven/model/PackagingTypeMapping.java
+++ b/src/main/java/org/zeroturnaround/javarebel/maven/model/PackagingTypeMapping.java
@@ -1,0 +1,38 @@
+package org.zeroturnaround.javarebel.maven.model;
+
+/**
+ * Packaging type mapping configuration.
+ */
+public class PackagingTypeMapping {
+  /**
+   * Custom packaging type to map.
+   *
+   * @parameter
+   * @required
+   */
+  private String type;
+
+  /**
+   * Standard packaging type to be mapped to.
+   *
+   * @parameter
+   * @required
+   */
+  private String mapping;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getMapping() {
+    return mapping;
+  }
+
+  public void setMapping(String mapping) {
+    this.mapping = mapping;
+  }
+}


### PR DESCRIPTION
This change adds a new 'packagingTypeMappings' configuration setting to
support mapping of custom packaging types to standard packaging types.
Example configuration:

  <configuration>
    <packagingTypeMappings>
      <packagingTypeMapping>
        <type>custom-jar</type>
        <mapping>jar</mapping>
      </packagingTypeMapping>
    </packagingTypeMappings>
  </configuration>