### PR TITLE
generate-rebel-remote (JR-9827)

### DIFF
--- a/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
+++ b/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
@@ -1,6 +1,12 @@
 package org.zeroturnaround.javarebel.maven;
 
-import java.io.*;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
+++ b/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
@@ -51,6 +51,7 @@ public class GenerateRebelMojo extends AbstractMojo {
 
   private static final Set JAR_PACKAGING = new HashSet();
   private static final Set WAR_PACKAGING = new HashSet();
+  public static final String CHARSET_NAME = "UTF-8";
 
   static {
     JAR_PACKAGING.addAll(Arrays.asList(new String[]{"jar", "ejb", "ejb3", "nbm", "hk2-jar", "bundle", "eclipse-plugin", "atlassian-plugin"}));
@@ -302,7 +303,7 @@ public class GenerateRebelMojo extends AbstractMojo {
 
       try {
         rebelXmlDirectory.mkdirs();
-        w = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(rebelXmlFile), "UTF-8"));
+        w = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(rebelXmlFile), CHARSET_NAME));
         builder.writeXml(w);
 
       } catch (IOException e) {
@@ -344,7 +345,7 @@ public class GenerateRebelMojo extends AbstractMojo {
 
     try {
       rebelXmlDirectory.mkdirs();
-      w = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(rebelRemoteXmlFile), "UTF-8"));
+      w = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(rebelRemoteXmlFile), CHARSET_NAME));
       generateRebelRemoteXml(w);
 
     } catch (IOException e) {
@@ -365,7 +366,7 @@ public class GenerateRebelMojo extends AbstractMojo {
    */
   private void generateRebelRemoteXml(Writer w) throws IOException {
 
-    String moduleId = URLEncoder.encode( getProject().getArtifactId(), "UTF-8").replaceAll("\\.", "_2E");
+    String moduleId = URLEncoder.encode( getProject().getArtifactId(), CHARSET_NAME).replaceAll("\\.", "_2E");
 
     w.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<rebel-remote xmlns=\"http://www.zeroturnaround.com/rebel/remote\">\n" +

--- a/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
+++ b/src/main/java/org/zeroturnaround/javarebel/maven/GenerateRebelMojo.java
@@ -328,12 +328,7 @@ public class GenerateRebelMojo extends AbstractMojo {
    */
   private void generateRebelRemoteXmlFile() throws MojoExecutionException {
 
-    File rebelRemoteXmlFile;
-    if( generateRebelRemote) {
-      rebelRemoteXmlFile = new File(rebelXmlDirectory, "rebel-remote.xml").getAbsoluteFile();
-    } else {
-      rebelRemoteXmlFile = null;
-    }
+    File rebelRemoteXmlFile = new File(rebelXmlDirectory, "rebel-remote.xml").getAbsoluteFile();
     getLog().info("Generating rebel-remote.xml on : " + rebelRemoteXmlFile.getAbsolutePath());
 
     Writer w = null;


### PR DESCRIPTION
This change adds the ability to generate the rebel-remote.xml. This is a simple aproach, and the enconding part need to be changed withthe code you use in the JRebel plugin for IDE to generate the rebel-remote.xml 